### PR TITLE
Newer version of M1_SA controller OA/CS blocks

### DIFF
--- a/src/actuators/center/M1SA_F_Control_CS.c
+++ b/src/actuators/center/M1SA_F_Control_CS.c
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_CS'.
  *
- * Model version                  : 1.785
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 11:20:29 2022
+ * C/C++ source code generated on : Wed Mar  9 10:44:51 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */
@@ -34,13 +32,16 @@ real_T CSseg_LC2CG[36] = { -0.43533006963859777, -0.49723457223199613,
                                                                  * Referenced by: '<S1>/CSseg_LC2CG'
                                                                  */
 
-real_T OAseg_SA_dynDen[2] = { 1.0, -0.53348809109110329 } ;/* Variable: OAseg_SA_dynDen
+real_T CSseg_SA_dynDen[2] = { 1.0, -0.53348809109110329 } ;/* Variable: CSseg_SA_dynDen
                                                             * Referenced by: '<S1>/CSseg_SA_dyn'
                                                             */
 
-real_T OAseg_SA_dynNum[2] = { 0.25752323685913081, 0.20898867204976596 } ;/* Variable: OAseg_SA_dynNum
+real_T CSseg_SA_dynNum[2] = { 0.25752323685913081, 0.20898867204976596 } ;/* Variable: CSseg_SA_dynNum
                                                                       * Referenced by: '<S1>/CSseg_SA_dyn'
                                                                       */
+
+/* Block states (default storage) */
+DW_M1SA_F_Control_CS_T M1SA_F_Control_CS_DW;
 
 /* External inputs (root inport signals with default storage) */
 ExtU_M1SA_F_Control_CS_T M1SA_F_Control_CS_U;
@@ -64,18 +65,22 @@ void M1SA_F_Control_CS_step(void)
   real_T rtb_Mycontroller;
   real_T rtb_Mzcontroller;
   real_T denAccum;
+  real_T rtb_CSseg_SA_dyn[306];
   real_T tmp[6];
   int32_T i;
-  int32_T k;
-  real_T M1SA_F_Control_CS_CSseg_SA_dyn_tmp_p[306];
+  int32_T i_0;
+  real_T CSseg_SA_dyn_tmp[306];
+  int32_T i_1;
 
   /* Gain: '<S1>/CSseg_LC2CG' incorporates:
    *  Inport: '<Root>/HP_LC'
    */
   for (i = 0; i < 6; i++) {
     rtb_CSseg_LC2CG[i] = 0.0;
-    for (k = 0; k < 6; k++) {
-      rtb_CSseg_LC2CG[i] += CSseg_LC2CG[6 * k + i] * M1SA_F_Control_CS_U.HP_LC[k];
+    i_1 = 0;
+    for (i_0 = 0; i_0 < 6; i_0++) {
+      rtb_CSseg_LC2CG[i] += CSseg_LC2CG[i_1 + i] * M1SA_F_Control_CS_U.HP_LC[i_0];
+      i_1 += 6;
     }
   }
 
@@ -84,54 +89,54 @@ void M1SA_F_Control_CS_step(void)
   /* DiscreteStateSpace: '<S2>/Fx controller' */
   {
     rtb_Fxcontroller = (-6.8610656930319749)*
-      M1SA_F_Control_CS_Fxcontroller_DSTATE[0]
-      + (8.7455483888425327)*M1SA_F_Control_CS_Fxcontroller_DSTATE[1]
-      + (1.8)*M1SA_F_Control_CS_Fxcontroller_DSTATE[2];
+      M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[0]
+      + (8.7455483888425327)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[1]
+      + (1.8)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[2];
     rtb_Fxcontroller += 0.024370329855613257*rtb_CSseg_LC2CG[0];
   }
 
   /* DiscreteStateSpace: '<S2>/Fy controller' */
   {
     rtb_Fycontroller = (-6.8610656930319749)*
-      M1SA_F_Control_CS_Fycontroller_DSTATE[0]
-      + (8.7455483888425327)*M1SA_F_Control_CS_Fycontroller_DSTATE[1]
-      + (1.8)*M1SA_F_Control_CS_Fycontroller_DSTATE[2];
+      M1SA_F_Control_CS_DW.Fycontroller_DSTATE[0]
+      + (8.7455483888425327)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[1]
+      + (1.8)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[2];
     rtb_Fycontroller += 0.024370329855613257*rtb_CSseg_LC2CG[1];
   }
 
   /* DiscreteStateSpace: '<S2>/Fz controller' */
   {
     rtb_Fzcontroller = (-11.624022612778809)*
-      M1SA_F_Control_CS_Fzcontroller_DSTATE[0]
-      + (13.310955668383137)*M1SA_F_Control_CS_Fzcontroller_DSTATE[1]
-      + (2.4)*M1SA_F_Control_CS_Fzcontroller_DSTATE[2];
+      M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[0]
+      + (13.310955668383137)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[1]
+      + (2.4)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[2];
     rtb_Fzcontroller += 0.026005628588130474*rtb_CSseg_LC2CG[2];
   }
 
   /* DiscreteStateSpace: '<S2>/Mx controller' */
   {
     rtb_Mxcontroller = (10.799355933329354)*
-      M1SA_F_Control_CS_Mxcontroller_DSTATE[0]
-      + (-10.162942348382657)*M1SA_F_Control_CS_Mxcontroller_DSTATE[1]
-      + (2.0)*M1SA_F_Control_CS_Mxcontroller_DSTATE[2];
+      M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[0]
+      + (-10.162942348382657)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[1]
+      + (2.0)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[2];
     rtb_Mxcontroller += 0.024170972941162154*rtb_CSseg_LC2CG[3];
   }
 
   /* DiscreteStateSpace: '<S2>/My controller' */
   {
     rtb_Mycontroller = (10.799355933329354)*
-      M1SA_F_Control_CS_Mycontroller_DSTATE[0]
-      + (-10.162942348382657)*M1SA_F_Control_CS_Mycontroller_DSTATE[1]
-      + (2.0)*M1SA_F_Control_CS_Mycontroller_DSTATE[2];
+      M1SA_F_Control_CS_DW.Mycontroller_DSTATE[0]
+      + (-10.162942348382657)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[1]
+      + (2.0)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[2];
     rtb_Mycontroller += 0.024170972941162154*rtb_CSseg_LC2CG[4];
   }
 
   /* DiscreteStateSpace: '<S2>/Mz controller' */
   {
     rtb_Mzcontroller = (-9.8843504316129263)*
-      M1SA_F_Control_CS_Mzcontroller_DSTATE[0]
-      + (11.363212843833221)*M1SA_F_Control_CS_Mzcontroller_DSTATE[1]
-      + (2.0)*M1SA_F_Control_CS_Mzcontroller_DSTATE[2];
+      M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[0]
+      + (11.363212843833221)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[1]
+      + (2.0)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[2];
     rtb_Mzcontroller += 0.02274996590750189*rtb_CSseg_LC2CG[5];
   }
 
@@ -142,13 +147,14 @@ void M1SA_F_Control_CS_step(void)
   tmp[3] = rtb_Mxcontroller;
   tmp[4] = rtb_Mycontroller;
   tmp[5] = rtb_Mzcontroller;
-  for (k = 0; k < 306; k++) {
-    /* Sum: '<S1>/Add' incorporates:
-     *  Gain: '<S1>/CSseg_Kbal'
-     */
-    denAccum = 0.0;
-    for (i = 0; i < 6; i++) {
-      denAccum += M1SA_F_Control_CS_ConstP.CSseg_Kbal_Gain[306 * i + k] * tmp[i];
+  for (i_0 = 0; i_0 < 306; i_0++) {
+    /* Gain: '<S1>/CSseg_Kbal' */
+    rtb_CSseg_SA_dyn[i_0] = 0.0;
+    i = 0;
+    for (i_1 = 0; i_1 < 6; i_1++) {
+      rtb_CSseg_SA_dyn[i_0] += M1SA_F_Control_CS_ConstP.CSseg_Kbal_Gain[i + i_0]
+        * tmp[i_1];
+      i += 306;
     }
 
     /* DiscreteTransferFcn: '<S1>/CSseg_SA_dyn' incorporates:
@@ -156,118 +162,127 @@ void M1SA_F_Control_CS_step(void)
      *  Inport: '<Root>/SA_offsetF_cmd'
      *  Sum: '<S1>/Add'
      */
-    denAccum = (denAccum + M1SA_F_Control_CS_U.SA_offsetF_cmd[k]) -
-      OAseg_SA_dynDen[1] * M1SA_F_Control_CS_CSseg_SA_dyn_states[k];
-    M1SA_F_Control_CS_Y.Res_Act_F[k] = OAseg_SA_dynNum[0] * denAccum +
-      OAseg_SA_dynNum[1] * M1SA_F_Control_CS_CSseg_SA_dyn_states[k];
-    M1SA_F_Control_CS_CSseg_SA_dyn_tmp_p[k] = denAccum;
+    denAccum = (rtb_CSseg_SA_dyn[i_0] + M1SA_F_Control_CS_U.SA_offsetF_cmd[i_0])
+      - CSseg_SA_dynDen[1] * M1SA_F_Control_CS_DW.CSseg_SA_dyn_states[i_0];
+    CSseg_SA_dyn_tmp[i_0] = denAccum;
+    denAccum *= CSseg_SA_dynNum[0];
+    rtb_CSseg_SA_dyn[i_0] = CSseg_SA_dynNum[1] *
+      M1SA_F_Control_CS_DW.CSseg_SA_dyn_states[i_0] + denAccum;
+
+    /* Outport: '<Root>/Res_Act_F' incorporates:
+     *  Gain: '<S1>/CSseg_Kbal'
+     */
+    M1SA_F_Control_CS_Y.Res_Act_F[i_0] = rtb_CSseg_SA_dyn[i_0];
   }
 
   /* Update for DiscreteStateSpace: '<S2>/Fx controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.569006949265765)*M1SA_F_Control_CS_Fxcontroller_DSTATE[0] +
-      (-0.01008281122133318)*M1SA_F_Control_CS_Fxcontroller_DSTATE[1]
-      + (0.10624490391424918)*M1SA_F_Control_CS_Fxcontroller_DSTATE[2];
+    xnew[0] = (0.569006949265765)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[0]
+      + (-0.01008281122133318)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[1]
+      + (0.10624490391424918)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[2];
     xnew[0] += (0.0041005206649182965)*rtb_CSseg_LC2CG[0];
-    xnew[1] = (0.69153586838988734)*M1SA_F_Control_CS_Fxcontroller_DSTATE[0]
-      + (0.40200245095801357)*M1SA_F_Control_CS_Fxcontroller_DSTATE[1]
-      + (-0.053834780381561045)*M1SA_F_Control_CS_Fxcontroller_DSTATE[2];
+    xnew[1] = (0.69153586838988734)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[0]
+      + (0.40200245095801357)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[1]
+      + (-0.053834780381561045)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[2];
     xnew[1] += (-0.0018292791104672016)*rtb_CSseg_LC2CG[0];
-    xnew[2] = (1.0)*M1SA_F_Control_CS_Fxcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_CSseg_LC2CG[0];
-    (void) memcpy(&M1SA_F_Control_CS_Fxcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_CS_DW.Fxcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S2>/Fy controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.569006949265765)*M1SA_F_Control_CS_Fycontroller_DSTATE[0] +
-      (-0.01008281122133318)*M1SA_F_Control_CS_Fycontroller_DSTATE[1]
-      + (0.10624490391424918)*M1SA_F_Control_CS_Fycontroller_DSTATE[2];
+    xnew[0] = (0.569006949265765)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[0]
+      + (-0.01008281122133318)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[1]
+      + (0.10624490391424918)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[2];
     xnew[0] += (0.0041005206649182965)*rtb_CSseg_LC2CG[1];
-    xnew[1] = (0.69153586838988734)*M1SA_F_Control_CS_Fycontroller_DSTATE[0]
-      + (0.40200245095801357)*M1SA_F_Control_CS_Fycontroller_DSTATE[1]
-      + (-0.053834780381561045)*M1SA_F_Control_CS_Fycontroller_DSTATE[2];
+    xnew[1] = (0.69153586838988734)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[0]
+      + (0.40200245095801357)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[1]
+      + (-0.053834780381561045)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[2];
     xnew[1] += (-0.0018292791104672016)*rtb_CSseg_LC2CG[1];
-    xnew[2] = (1.0)*M1SA_F_Control_CS_Fycontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_CS_DW.Fycontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_CSseg_LC2CG[1];
-    (void) memcpy(&M1SA_F_Control_CS_Fycontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_CS_DW.Fycontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S2>/Fz controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.30106701605566411)*M1SA_F_Control_CS_Fzcontroller_DSTATE[0]
-      + (-0.0031724351959647483)*M1SA_F_Control_CS_Fzcontroller_DSTATE[1]
-      + (0.13638180429146238)*M1SA_F_Control_CS_Fzcontroller_DSTATE[2];
+    xnew[0] = (0.30106701605566411)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[0]
+      + (-0.0031724351959647483)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[1]
+      + (0.13638180429146238)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[2];
     xnew[0] += (0.0051578505311074786)*rtb_CSseg_LC2CG[2];
-    xnew[1] = (0.69313056645169)*M1SA_F_Control_CS_Fzcontroller_DSTATE[0] +
-      (0.20728190413675984)*M1SA_F_Control_CS_Fzcontroller_DSTATE[1]
-      + (-0.00017021067138710554)*M1SA_F_Control_CS_Fzcontroller_DSTATE[2];
+    xnew[1] = (0.69313056645169)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[0]
+      + (0.20728190413675984)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[1]
+      + (-0.00017021067138710554)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[2];
     xnew[1] += (0.00017169440437669642)*rtb_CSseg_LC2CG[2];
-    xnew[2] = (1.0)*M1SA_F_Control_CS_Fzcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_CSseg_LC2CG[2];
-    (void) memcpy(&M1SA_F_Control_CS_Fzcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_CS_DW.Fzcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S2>/Mx controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.24588323456423145)*M1SA_F_Control_CS_Mxcontroller_DSTATE[0]
-      + (0.70467842450269291)*M1SA_F_Control_CS_Mxcontroller_DSTATE[1]
-      + (0.00081808803127932854)*M1SA_F_Control_CS_Mxcontroller_DSTATE[2];
+    xnew[0] = (0.24588323456423145)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[0]
+      + (0.70467842450269291)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[1]
+      + (0.00081808803127932854)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[2];
     xnew[0] += (0.00019581781538031463)*rtb_CSseg_LC2CG[3];
-    xnew[1] = (-0.00064951930680839346)*M1SA_F_Control_CS_Mxcontroller_DSTATE[0]
-      + (0.28867118809350589)*M1SA_F_Control_CS_Mxcontroller_DSTATE[1]
-      + (0.11653922223015478)*M1SA_F_Control_CS_Mxcontroller_DSTATE[2];
+    xnew[1] = (-0.00064951930680839346)*
+      M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[0]
+      + (0.28867118809350589)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[1]
+      + (0.11653922223015478)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[2];
     xnew[1] += (0.0044051041445438335)*rtb_CSseg_LC2CG[3];
-    xnew[2] = (1.0)*M1SA_F_Control_CS_Mxcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_CSseg_LC2CG[3];
-    (void) memcpy(&M1SA_F_Control_CS_Mxcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_CS_DW.Mxcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S2>/My controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.24588323456423145)*M1SA_F_Control_CS_Mycontroller_DSTATE[0]
-      + (0.70467842450269291)*M1SA_F_Control_CS_Mycontroller_DSTATE[1]
-      + (0.00081808803127932854)*M1SA_F_Control_CS_Mycontroller_DSTATE[2];
+    xnew[0] = (0.24588323456423145)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[0]
+      + (0.70467842450269291)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[1]
+      + (0.00081808803127932854)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[2];
     xnew[0] += (0.00019581781538031463)*rtb_CSseg_LC2CG[4];
-    xnew[1] = (-0.00064951930680839346)*M1SA_F_Control_CS_Mycontroller_DSTATE[0]
-      + (0.28867118809350589)*M1SA_F_Control_CS_Mycontroller_DSTATE[1]
-      + (0.11653922223015478)*M1SA_F_Control_CS_Mycontroller_DSTATE[2];
+    xnew[1] = (-0.00064951930680839346)*
+      M1SA_F_Control_CS_DW.Mycontroller_DSTATE[0]
+      + (0.28867118809350589)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[1]
+      + (0.11653922223015478)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[2];
     xnew[1] += (0.0044051041445438335)*rtb_CSseg_LC2CG[4];
-    xnew[2] = (1.0)*M1SA_F_Control_CS_Mycontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_CS_DW.Mycontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_CSseg_LC2CG[4];
-    (void) memcpy(&M1SA_F_Control_CS_Mycontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_CS_DW.Mycontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S2>/Mz controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.35318690302308442)*M1SA_F_Control_CS_Mzcontroller_DSTATE[0]
-      + (0.72011465131225016)*M1SA_F_Control_CS_Mzcontroller_DSTATE[1]
-      + (-0.0038868874920811648)*M1SA_F_Control_CS_Mzcontroller_DSTATE[2];
+    xnew[0] = (0.35318690302308442)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[0]
+      + (0.72011465131225016)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[1]
+      + (-0.0038868874920811648)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[2];
     xnew[0] += (-0.00035257232440118728)*rtb_CSseg_LC2CG[5];
-    xnew[1] = (-0.0034885015967498082)*M1SA_F_Control_CS_Mzcontroller_DSTATE[0]
-      + (0.25294477393664205)*M1SA_F_Control_CS_Mzcontroller_DSTATE[1]
-      + (-0.12437198598757729)*M1SA_F_Control_CS_Mzcontroller_DSTATE[2];
+    xnew[1] = (-0.0034885015967498082)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE
+      [0]
+      + (0.25294477393664205)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[1]
+      + (-0.12437198598757729)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[2];
     xnew[1] += (-0.0046911246844348262)*rtb_CSseg_LC2CG[5];
-    xnew[2] = (1.0)*M1SA_F_Control_CS_Mzcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_CSseg_LC2CG[5];
-    (void) memcpy(&M1SA_F_Control_CS_Mzcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_CS_DW.Mzcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteTransferFcn: '<S1>/CSseg_SA_dyn' */
-  memcpy((&(M1SA_F_Control_CS_CSseg_SA_dyn_states[0])),
-         &M1SA_F_Control_CS_CSseg_SA_dyn_tmp_p[0], 306U * sizeof(real_T));
+  memcpy(&M1SA_F_Control_CS_DW.CSseg_SA_dyn_states[0], &CSseg_SA_dyn_tmp[0],
+         306U * sizeof(real_T));
 }
 
 /* Model initialize function */
@@ -277,6 +292,10 @@ void M1SA_F_Control_CS_initialize(void)
 
   /* initialize error status */
   rtmSetErrorStatus(M1SA_F_Control_CS_M, (NULL));
+
+  /* states (dwork) */
+  (void) memset((void *)&M1SA_F_Control_CS_DW, 0,
+                sizeof(DW_M1SA_F_Control_CS_T));
 
   /* external inputs */
   (void)memset(&M1SA_F_Control_CS_U, 0, sizeof(ExtU_M1SA_F_Control_CS_T));

--- a/src/actuators/center/M1SA_F_Control_CS.h
+++ b/src/actuators/center/M1SA_F_Control_CS.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_CS'.
  *
- * Model version                  : 1.785
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 11:20:29 2022
+ * C/C++ source code generated on : Wed Mar  9 10:44:51 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */
@@ -34,6 +32,17 @@
 #ifndef rtmSetErrorStatus
 # define rtmSetErrorStatus(rtm, val)   ((rtm)->errorStatus = (val))
 #endif
+
+/* Block states (default storage) for system '<Root>' */
+typedef struct {
+  real_T Fxcontroller_DSTATE[3];       /* '<S2>/Fx controller' */
+  real_T Fycontroller_DSTATE[3];       /* '<S2>/Fy controller' */
+  real_T Fzcontroller_DSTATE[3];       /* '<S2>/Fz controller' */
+  real_T Mxcontroller_DSTATE[3];       /* '<S2>/Mx controller' */
+  real_T Mycontroller_DSTATE[3];       /* '<S2>/My controller' */
+  real_T Mzcontroller_DSTATE[3];       /* '<S2>/Mz controller' */
+  real_T CSseg_SA_dyn_states[306];     /* '<S1>/CSseg_SA_dyn' */
+} DW_M1SA_F_Control_CS_T;
 
 /* Constant parameters (default storage) */
 typedef struct {
@@ -59,6 +68,9 @@ struct tag_RTM_M1SA_F_Control_CS_T {
   const char_T * volatile errorStatus;
 };
 
+/* Block states (default storage) */
+extern DW_M1SA_F_Control_CS_T M1SA_F_Control_CS_DW;
+
 /* External inputs (root inport signals with default storage) */
 extern ExtU_M1SA_F_Control_CS_T M1SA_F_Control_CS_U;
 
@@ -79,10 +91,10 @@ extern const ConstP_M1SA_F_Control_CS_T M1SA_F_Control_CS_ConstP;
 extern real_T CSseg_LC2CG[36];         /* Variable: CSseg_LC2CG
                                         * Referenced by: '<S1>/CSseg_LC2CG'
                                         */
-extern real_T OAseg_SA_dynDen[2];      /* Variable: OAseg_SA_dynDen
+extern real_T CSseg_SA_dynDen[2];      /* Variable: CSseg_SA_dynDen
                                         * Referenced by: '<S1>/CSseg_SA_dyn'
                                         */
-extern real_T OAseg_SA_dynNum[2];      /* Variable: OAseg_SA_dynNum
+extern real_T CSseg_SA_dynNum[2];      /* Variable: CSseg_SA_dynNum
                                         * Referenced by: '<S1>/CSseg_SA_dyn'
                                         */
 

--- a/src/actuators/center/M1SA_F_Control_CS_data.c
+++ b/src/actuators/center/M1SA_F_Control_CS_data.c
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_CS'.
  *
- * Model version                  : 1.785
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 11:20:29 2022
+ * C/C++ source code generated on : Wed Mar  9 10:44:51 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */

--- a/src/actuators/center/M1SA_F_Control_CS_private.h
+++ b/src/actuators/center/M1SA_F_Control_CS_private.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_CS'.
  *
- * Model version                  : 1.785
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 11:20:29 2022
+ * C/C++ source code generated on : Wed Mar  9 10:44:51 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */
@@ -18,18 +16,6 @@
 #ifndef RTW_HEADER_M1SA_F_Control_CS_private_h_
 #define RTW_HEADER_M1SA_F_Control_CS_private_h_
 #include "rtwtypes.h"
-
-/* Exported data declaration */
-
-/* Declaration for custom storage class: ImportFromFile */
-extern real_T M1SA_F_Control_CS_CSseg_SA_dyn_states[306];
-extern real_T M1SA_F_Control_CS_Fxcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_CS_Fycontroller_DSTATE[3];
-extern real_T M1SA_F_Control_CS_Fzcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_CS_Mxcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_CS_Mycontroller_DSTATE[3];
-extern real_T M1SA_F_Control_CS_Mzcontroller_DSTATE[3];
-
 #endif                                 /* RTW_HEADER_M1SA_F_Control_CS_private_h_ */
 
 /*

--- a/src/actuators/center/M1SA_F_Control_CS_types.h
+++ b/src/actuators/center/M1SA_F_Control_CS_types.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_CS'.
  *
- * Model version                  : 1.785
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 11:20:29 2022
+ * C/C++ source code generated on : Wed Mar  9 10:44:51 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */

--- a/src/actuators/center/rtwtypes.h
+++ b/src/actuators/center/rtwtypes.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_CS'.
  *
- * Model version                  : 1.785
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 11:20:29 2022
+ * C/C++ source code generated on : Wed Mar  9 10:44:51 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */

--- a/src/actuators/outer/M1SA_F_Control_OA.c
+++ b/src/actuators/outer/M1SA_F_Control_OA.c
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_OA'.
  *
- * Model version                  : 1.779
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 10:43:30 2022
+ * C/C++ source code generated on : Wed Mar  9 10:39:46 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */
@@ -43,6 +41,9 @@ real_T OAseg_SA_dynNum[2] = { 0.25752323685913081, 0.20898867204976596 } ;/* Var
                                                                       * Referenced by: '<S1>/OAseg_SA_dyn'
                                                                       */
 
+/* Block states (default storage) */
+DW_M1SA_F_Control_OA_T M1SA_F_Control_OA_DW;
+
 /* External inputs (root inport signals with default storage) */
 ExtU_M1SA_F_Control_OA_T M1SA_F_Control_OA_U;
 
@@ -68,16 +69,18 @@ void M1SA_F_Control_OA_step(void)
   real_T tmp[6];
   int32_T i;
   int32_T i_0;
-  real_T M1SA_F_Control_OA_OAseg_SA_dyn_tmp_p[335];
+  real_T OAseg_SA_dyn_tmp[335];
+  int32_T i_1;
 
   /* Gain: '<S1>/OAseg_LC2CG' incorporates:
    *  Inport: '<Root>/HP_LC'
    */
   for (i = 0; i < 6; i++) {
     rtb_OAseg_LC2CG[i] = 0.0;
+    i_1 = 0;
     for (i_0 = 0; i_0 < 6; i_0++) {
-      rtb_OAseg_LC2CG[i] += OAseg_LC2CG[6 * i_0 + i] *
-        M1SA_F_Control_OA_U.HP_LC[i_0];
+      rtb_OAseg_LC2CG[i] += OAseg_LC2CG[i_1 + i] * M1SA_F_Control_OA_U.HP_LC[i_0];
+      i_1 += 6;
     }
   }
 
@@ -86,53 +89,54 @@ void M1SA_F_Control_OA_step(void)
   /* DiscreteStateSpace: '<S3>/Fx controller' */
   {
     rtb_Fxcontroller = (-6.8610656930319749)*
-      M1SA_F_Control_OA_Fxcontroller_DSTATE[0]
-      + (8.7455483888425327)*M1SA_F_Control_OA_Fxcontroller_DSTATE[1]
-      + (1.8)*M1SA_F_Control_OA_Fxcontroller_DSTATE[2];
+      M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[0]
+      + (8.7455483888425327)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[1]
+      + (1.8)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[2];
     rtb_Fxcontroller += 0.024370329855613257*rtb_OAseg_LC2CG[0];
   }
 
   /* DiscreteStateSpace: '<S3>/Fy controller' */
   {
     rtb_Fycontroller = (-6.8610656930319749)*
-      M1SA_F_Control_OA_Fycontroller_DSTATE[0]
-      + (8.7455483888425327)*M1SA_F_Control_OA_Fycontroller_DSTATE[1]
-      + (1.8)*M1SA_F_Control_OA_Fycontroller_DSTATE[2];
+      M1SA_F_Control_OA_DW.Fycontroller_DSTATE[0]
+      + (8.7455483888425327)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[1]
+      + (1.8)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[2];
     rtb_Fycontroller += 0.024370329855613257*rtb_OAseg_LC2CG[1];
   }
 
   /* DiscreteStateSpace: '<S3>/Fz controller' */
   {
     rtb_Fzcontroller = (-11.022867857707155)*
-      M1SA_F_Control_OA_Fzcontroller_DSTATE[0]
-      + (14.667973716577512)*M1SA_F_Control_OA_Fzcontroller_DSTATE[1]
-      + (2.4)*M1SA_F_Control_OA_Fzcontroller_DSTATE[2];
+      M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[0]
+      + (14.667973716577512)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[1]
+      + (2.4)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[2];
     rtb_Fzcontroller += 0.025354461628138772*rtb_OAseg_LC2CG[2];
   }
 
   /* DiscreteStateSpace: '<S3>/Mx controller' */
   {
     rtb_Mxcontroller = (-10.04307867717106)*
-      M1SA_F_Control_OA_Mxcontroller_DSTATE[0]
-      + (10.41998468921483)*M1SA_F_Control_OA_Mxcontroller_DSTATE[1]
-      + (2.0)*M1SA_F_Control_OA_Mxcontroller_DSTATE[2];
+      M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[0]
+      + (10.41998468921483)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[1]
+      + (2.0)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[2];
     rtb_Mxcontroller += 0.024505707216075836*rtb_OAseg_LC2CG[3];
   }
 
   /* DiscreteStateSpace: '<S3>/My controller' */
   {
     rtb_Mycontroller = (-10.04307867717106)*
-      M1SA_F_Control_OA_Mycontroller_DSTATE[0]
-      + (10.41998468921483)*M1SA_F_Control_OA_Mycontroller_DSTATE[1]
-      + (2.0)*M1SA_F_Control_OA_Mycontroller_DSTATE[2];
+      M1SA_F_Control_OA_DW.Mycontroller_DSTATE[0]
+      + (10.41998468921483)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[1]
+      + (2.0)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[2];
     rtb_Mycontroller += 0.024505707216075836*rtb_OAseg_LC2CG[4];
   }
 
   /* DiscreteStateSpace: '<S3>/Mz controller' */
   {
-    rtb_Mzcontroller = (-9.4551745922133)*M1SA_F_Control_OA_Mzcontroller_DSTATE
-      [0] + (11.4653232391471)*M1SA_F_Control_OA_Mzcontroller_DSTATE[1]
-      + (2.0)*M1SA_F_Control_OA_Mzcontroller_DSTATE[2];
+    rtb_Mzcontroller = (-9.4551745922133)*
+      M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[0]
+      + (11.4653232391471)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[1]
+      + (2.0)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[2];
     rtb_Mzcontroller += 0.022969235998287645*rtb_OAseg_LC2CG[5];
   }
 
@@ -146,129 +150,139 @@ void M1SA_F_Control_OA_step(void)
   for (i_0 = 0; i_0 < 335; i_0++) {
     /* Gain: '<S1>/OAseg_Kbal' */
     OFL_act_Fcmd[i_0] = 0.0;
-    for (i = 0; i < 6; i++) {
-      OFL_act_Fcmd[i_0] += M1SA_F_Control_OA_ConstP.OAseg_Kbal_Gain[335 * i +
-        i_0] * tmp[i];
+    i = 0;
+    for (i_1 = 0; i_1 < 6; i_1++) {
+      OFL_act_Fcmd[i_0] += M1SA_F_Control_OA_ConstP.OAseg_Kbal_Gain[i + i_0] *
+        tmp[i_1];
+      i += 335;
     }
 
-    /* End of Gain: '<S1>/OAseg_Kbal' */
-
     /* DiscreteTransferFcn: '<S1>/OAseg_SA_dyn' incorporates:
+     *  Gain: '<S1>/OAseg_Kbal'
      *  Inport: '<Root>/SA_offsetF_cmd'
      *  Sum: '<S1>/Add'
      */
     denAccum = (OFL_act_Fcmd[i_0] + M1SA_F_Control_OA_U.SA_offsetF_cmd[i_0]) -
-      OAseg_SA_dynDen[1] * M1SA_F_Control_OA_OAseg_SA_dyn_states[i_0];
-    M1SA_F_Control_OA_Y.Res_Act_F[i_0] = OAseg_SA_dynNum[0] * denAccum +
-      OAseg_SA_dynNum[1] * M1SA_F_Control_OA_OAseg_SA_dyn_states[i_0];
-    M1SA_F_Control_OA_OAseg_SA_dyn_tmp_p[i_0] = denAccum;
+      OAseg_SA_dynDen[1] * M1SA_F_Control_OA_DW.OAseg_SA_dyn_states[i_0];
+    OAseg_SA_dyn_tmp[i_0] = denAccum;
+    denAccum *= OAseg_SA_dynNum[0];
+
+    /* Outport: '<Root>/Res_Act_F' incorporates:
+     *  DiscreteTransferFcn: '<S1>/OAseg_SA_dyn'
+     *  Gain: '<S1>/OAseg_Kbal'
+     */
+    M1SA_F_Control_OA_Y.Res_Act_F[i_0] = OAseg_SA_dynNum[1] *
+      M1SA_F_Control_OA_DW.OAseg_SA_dyn_states[i_0] + denAccum;
   }
 
   /* Update for DiscreteStateSpace: '<S3>/Fx controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.569006949265765)*M1SA_F_Control_OA_Fxcontroller_DSTATE[0] +
-      (-0.01008281122133318)*M1SA_F_Control_OA_Fxcontroller_DSTATE[1]
-      + (0.10624490391424918)*M1SA_F_Control_OA_Fxcontroller_DSTATE[2];
+    xnew[0] = (0.569006949265765)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[0]
+      + (-0.01008281122133318)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[1]
+      + (0.10624490391424918)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[2];
     xnew[0] += (0.0041005206649182965)*rtb_OAseg_LC2CG[0];
-    xnew[1] = (0.69153586838988734)*M1SA_F_Control_OA_Fxcontroller_DSTATE[0]
-      + (0.40200245095801357)*M1SA_F_Control_OA_Fxcontroller_DSTATE[1]
-      + (-0.053834780381561045)*M1SA_F_Control_OA_Fxcontroller_DSTATE[2];
+    xnew[1] = (0.69153586838988734)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[0]
+      + (0.40200245095801357)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[1]
+      + (-0.053834780381561045)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[2];
     xnew[1] += (-0.0018292791104672016)*rtb_OAseg_LC2CG[0];
-    xnew[2] = (1.0)*M1SA_F_Control_OA_Fxcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_OAseg_LC2CG[0];
-    (void) memcpy(&M1SA_F_Control_OA_Fxcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_OA_DW.Fxcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S3>/Fy controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.569006949265765)*M1SA_F_Control_OA_Fycontroller_DSTATE[0] +
-      (-0.01008281122133318)*M1SA_F_Control_OA_Fycontroller_DSTATE[1]
-      + (0.10624490391424918)*M1SA_F_Control_OA_Fycontroller_DSTATE[2];
+    xnew[0] = (0.569006949265765)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[0]
+      + (-0.01008281122133318)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[1]
+      + (0.10624490391424918)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[2];
     xnew[0] += (0.0041005206649182965)*rtb_OAseg_LC2CG[1];
-    xnew[1] = (0.69153586838988734)*M1SA_F_Control_OA_Fycontroller_DSTATE[0]
-      + (0.40200245095801357)*M1SA_F_Control_OA_Fycontroller_DSTATE[1]
-      + (-0.053834780381561045)*M1SA_F_Control_OA_Fycontroller_DSTATE[2];
+    xnew[1] = (0.69153586838988734)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[0]
+      + (0.40200245095801357)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[1]
+      + (-0.053834780381561045)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[2];
     xnew[1] += (-0.0018292791104672016)*rtb_OAseg_LC2CG[1];
-    xnew[2] = (1.0)*M1SA_F_Control_OA_Fycontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_OA_DW.Fycontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_OAseg_LC2CG[1];
-    (void) memcpy(&M1SA_F_Control_OA_Fycontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_OA_DW.Fycontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S3>/Fz controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.3222450105115563)*M1SA_F_Control_OA_Fzcontroller_DSTATE[0]
-      + (-0.013311547842537916)*M1SA_F_Control_OA_Fzcontroller_DSTATE[1]
-      + (0.13664330677325981)*M1SA_F_Control_OA_Fzcontroller_DSTATE[2];
+    xnew[0] = (0.3222450105115563)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[0]
+      + (-0.013311547842537916)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[1]
+      + (0.13664330677325981)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[2];
     xnew[0] += (0.005170012950170496)*rtb_OAseg_LC2CG[2];
-    xnew[1] = (0.66124884843011622)*M1SA_F_Control_OA_Fzcontroller_DSTATE[0]
-      + (0.13460444259831861)*M1SA_F_Control_OA_Fzcontroller_DSTATE[1]
-      + (-0.0021677560864410391)*M1SA_F_Control_OA_Fzcontroller_DSTATE[2];
+    xnew[1] = (0.66124884843011622)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[0]
+      + (0.13460444259831861)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[1]
+      + (-0.0021677560864410391)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[2];
     xnew[1] += (6.2680779829774611E-5)*rtb_OAseg_LC2CG[2];
-    xnew[2] = (1.0)*M1SA_F_Control_OA_Fzcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_OAseg_LC2CG[2];
-    (void) memcpy(&M1SA_F_Control_OA_Fzcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_OA_DW.Fzcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S3>/Mx controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.29778010884776307)*M1SA_F_Control_OA_Mxcontroller_DSTATE[0]
-      + (0.71505921377142712)*M1SA_F_Control_OA_Mxcontroller_DSTATE[1]
-      + (-0.0021601236457374955)*M1SA_F_Control_OA_Mxcontroller_DSTATE[2];
+    xnew[0] = (0.29778010884776307)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[0]
+      + (0.71505921377142712)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[1]
+      + (-0.0021601236457374955)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[2];
     xnew[0] += (-0.00026117608623345441)*rtb_OAseg_LC2CG[3];
-    xnew[1] = (-0.00024258661738509195)*M1SA_F_Control_OA_Mxcontroller_DSTATE[0]
-      + (0.27143897782429549)*M1SA_F_Control_OA_Mxcontroller_DSTATE[1]
-      + (-0.11649383326807114)*M1SA_F_Control_OA_Mxcontroller_DSTATE[2];
+    xnew[1] = (-0.00024258661738509195)*
+      M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[0]
+      + (0.27143897782429549)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[1]
+      + (-0.11649383326807114)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[2];
     xnew[1] += (-0.0043992827840101858)*rtb_OAseg_LC2CG[3];
-    xnew[2] = (1.0)*M1SA_F_Control_OA_Mxcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_OAseg_LC2CG[3];
-    (void) memcpy(&M1SA_F_Control_OA_Mxcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_OA_DW.Mxcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S3>/My controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.29778010884776307)*M1SA_F_Control_OA_Mycontroller_DSTATE[0]
-      + (0.71505921377142712)*M1SA_F_Control_OA_Mycontroller_DSTATE[1]
-      + (-0.0021601236457374955)*M1SA_F_Control_OA_Mycontroller_DSTATE[2];
+    xnew[0] = (0.29778010884776307)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[0]
+      + (0.71505921377142712)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[1]
+      + (-0.0021601236457374955)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[2];
     xnew[0] += (-0.00026117608623345441)*rtb_OAseg_LC2CG[4];
-    xnew[1] = (-0.00024258661738509195)*M1SA_F_Control_OA_Mycontroller_DSTATE[0]
-      + (0.27143897782429549)*M1SA_F_Control_OA_Mycontroller_DSTATE[1]
-      + (-0.11649383326807114)*M1SA_F_Control_OA_Mycontroller_DSTATE[2];
+    xnew[1] = (-0.00024258661738509195)*
+      M1SA_F_Control_OA_DW.Mycontroller_DSTATE[0]
+      + (0.27143897782429549)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[1]
+      + (-0.11649383326807114)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[2];
     xnew[1] += (-0.0043992827840101858)*rtb_OAseg_LC2CG[4];
-    xnew[2] = (1.0)*M1SA_F_Control_OA_Mycontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_OA_DW.Mycontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_OAseg_LC2CG[4];
-    (void) memcpy(&M1SA_F_Control_OA_Mycontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_OA_DW.Mycontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteStateSpace: '<S3>/Mz controller' */
   {
     real_T xnew[3];
-    xnew[0] = (0.38195738947508884)*M1SA_F_Control_OA_Mzcontroller_DSTATE[0]
-      + (0.72039580968966876)*M1SA_F_Control_OA_Mzcontroller_DSTATE[1]
-      + (-0.0047245815737020904)*M1SA_F_Control_OA_Mzcontroller_DSTATE[2];
+    xnew[0] = (0.38195738947508884)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[0]
+      + (0.72039580968966876)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[1]
+      + (-0.0047245815737020904)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[2];
     xnew[0] += (-0.00039049368346384173)*rtb_OAseg_LC2CG[5];
-    xnew[1] = (-0.0066509471364728252)*M1SA_F_Control_OA_Mzcontroller_DSTATE[0]
-      + (0.24351874678335261)*M1SA_F_Control_OA_Mzcontroller_DSTATE[1]
-      + (-0.12438032071830714)*M1SA_F_Control_OA_Mzcontroller_DSTATE[2];
+    xnew[1] = (-0.0066509471364728252)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE
+      [0]
+      + (0.24351874678335261)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[1]
+      + (-0.12438032071830714)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[2];
     xnew[1] += (-0.0046882022587151594)*rtb_OAseg_LC2CG[5];
-    xnew[2] = (1.0)*M1SA_F_Control_OA_Mzcontroller_DSTATE[2];
+    xnew[2] = (1.0)*M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[2];
     xnew[2] += (0.039999999999999994)*rtb_OAseg_LC2CG[5];
-    (void) memcpy(&M1SA_F_Control_OA_Mzcontroller_DSTATE[0], xnew,
+    (void) memcpy(&M1SA_F_Control_OA_DW.Mzcontroller_DSTATE[0], xnew,
                   sizeof(real_T)*3);
   }
 
   /* Update for DiscreteTransferFcn: '<S1>/OAseg_SA_dyn' */
-  memcpy((&(M1SA_F_Control_OA_OAseg_SA_dyn_states[0])),
-         &M1SA_F_Control_OA_OAseg_SA_dyn_tmp_p[0], 335U * sizeof(real_T));
+  memcpy(&M1SA_F_Control_OA_DW.OAseg_SA_dyn_states[0], &OAseg_SA_dyn_tmp[0],
+         335U * sizeof(real_T));
 }
 
 /* Model initialize function */
@@ -278,6 +292,10 @@ void M1SA_F_Control_OA_initialize(void)
 
   /* initialize error status */
   rtmSetErrorStatus(M1SA_F_Control_OA_M, (NULL));
+
+  /* states (dwork) */
+  (void) memset((void *)&M1SA_F_Control_OA_DW, 0,
+                sizeof(DW_M1SA_F_Control_OA_T));
 
   /* external inputs */
   (void)memset(&M1SA_F_Control_OA_U, 0, sizeof(ExtU_M1SA_F_Control_OA_T));

--- a/src/actuators/outer/M1SA_F_Control_OA.h
+++ b/src/actuators/outer/M1SA_F_Control_OA.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_OA'.
  *
- * Model version                  : 1.779
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 10:43:30 2022
+ * C/C++ source code generated on : Wed Mar  9 10:39:46 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */
@@ -35,6 +33,17 @@
 # define rtmSetErrorStatus(rtm, val)   ((rtm)->errorStatus = (val))
 #endif
 
+/* Block states (default storage) for system '<Root>' */
+typedef struct {
+  real_T Fxcontroller_DSTATE[3];       /* '<S3>/Fx controller' */
+  real_T Fycontroller_DSTATE[3];       /* '<S3>/Fy controller' */
+  real_T Fzcontroller_DSTATE[3];       /* '<S3>/Fz controller' */
+  real_T Mxcontroller_DSTATE[3];       /* '<S3>/Mx controller' */
+  real_T Mycontroller_DSTATE[3];       /* '<S3>/My controller' */
+  real_T Mzcontroller_DSTATE[3];       /* '<S3>/Mz controller' */
+  real_T OAseg_SA_dyn_states[335];     /* '<S1>/OAseg_SA_dyn' */
+} DW_M1SA_F_Control_OA_T;
+
 /* Constant parameters (default storage) */
 typedef struct {
   /* Expression: m1sys{1}.Kbal
@@ -58,6 +67,9 @@ typedef struct {
 struct tag_RTM_M1SA_F_Control_OA_T {
   const char_T * volatile errorStatus;
 };
+
+/* Block states (default storage) */
+extern DW_M1SA_F_Control_OA_T M1SA_F_Control_OA_DW;
 
 /* External inputs (root inport signals with default storage) */
 extern ExtU_M1SA_F_Control_OA_T M1SA_F_Control_OA_U;

--- a/src/actuators/outer/M1SA_F_Control_OA_data.c
+++ b/src/actuators/outer/M1SA_F_Control_OA_data.c
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_OA'.
  *
- * Model version                  : 1.779
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 10:43:30 2022
+ * C/C++ source code generated on : Wed Mar  9 10:39:46 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */

--- a/src/actuators/outer/M1SA_F_Control_OA_private.h
+++ b/src/actuators/outer/M1SA_F_Control_OA_private.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_OA'.
  *
- * Model version                  : 1.779
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 10:43:30 2022
+ * C/C++ source code generated on : Wed Mar  9 10:39:46 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */
@@ -21,17 +19,6 @@
 
 /* Imported (extern) block signals */
 extern real_T OFL_act_Fcmd[335];       /* '<S1>/OAseg_Kbal' */
-
-/* Exported data declaration */
-
-/* Declaration for custom storage class: ImportFromFile */
-extern real_T M1SA_F_Control_OA_Fxcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_OA_Fycontroller_DSTATE[3];
-extern real_T M1SA_F_Control_OA_Fzcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_OA_Mxcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_OA_Mycontroller_DSTATE[3];
-extern real_T M1SA_F_Control_OA_Mzcontroller_DSTATE[3];
-extern real_T M1SA_F_Control_OA_OAseg_SA_dyn_states[335];
 
 #endif                                 /* RTW_HEADER_M1SA_F_Control_OA_private_h_ */
 

--- a/src/actuators/outer/M1SA_F_Control_OA_types.h
+++ b/src/actuators/outer/M1SA_F_Control_OA_types.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_OA'.
  *
- * Model version                  : 1.779
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 10:43:30 2022
+ * C/C++ source code generated on : Wed Mar  9 10:39:46 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */

--- a/src/actuators/outer/rtwtypes.h
+++ b/src/actuators/outer/rtwtypes.h
@@ -3,14 +3,12 @@
  *
  * Code generated for Simulink model 'M1SA_F_Control_OA'.
  *
- * Model version                  : 1.779
+ * Model version                  : 1.966
  * Simulink Coder version         : 9.0 (R2018b) 24-May-2018
- * C/C++ source code generated on : Thu Feb 10 10:43:30 2022
+ * C/C++ source code generated on : Wed Mar  9 10:39:46 2022
  *
  * Target selection: ert.tlc
- * Embedded hardware selection: Intel->x86-64 (Windows64)
- * Emulation hardware selection:
- *    Differs from embedded hardware (MATLAB Host)
+ * Embedded hardware selection: Intel->x86-64 (Linux 64)
  * Code generation objectives: Unspecified
  * Validation result: Not run
  */


### PR DESCRIPTION
In this new version, the structures `DW_M1SA_F_Control_OA_T` and `DW_M1SA_F_Control_CS_T` are defined in `M1SA_F_Control_OA` and `M1SA_F_Control_CS`, respectively. It is supposed that this may solve compilation errors.